### PR TITLE
Make repo work with npm instead of pnpm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 npm-debug.log*
 yarn.lock
 .vscode/launch.json
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 .DS_Store
 *.tsbuildinfo
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -30,18 +30,17 @@
   },
   "engines": {
     "node": ">=18.10",
-    "pnpm": ">=9.1"
+    "npm": ">=9.1"
   },
-  "packageManager": "pnpm@9.1.4",
+  "packageManager": "npm@9.1.4",
   "main": "index.js",
   "scripts": {
-    "preinstall": "npx only-allow pnpm",
     "build": "tsc && gulp build:icons",
     "dev": "tsc --watch",
     "format": "prettier nodes credentials --write",
     "lint": "eslint nodes",
     "lintfix": "eslint nodes credentials package.json --fix",
-    "prepublishOnly": "pnpm build && pnpm lint -c .eslintrc.prepublish.js nodes"
+    "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "format": "prettier nodes credentials --write",
     "lint": "eslint nodes",
     "lintfix": "eslint nodes credentials package.json --fix",
-    "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes"
+    "prepublishOnly": "npm run build && npm run lint -- -c .eslintrc.prepublish.js nodes"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Update `package.json` to use npm instead of pnpm.

* Change `engines` to specify `npm` instead of `pnpm`.
* Remove the `preinstall` script.
* Update the `prepublishOnly` script to use `npm` commands instead of `pnpm`.

Update `.gitignore` and `.npmignore` to include `package-lock.json`.

* Add `package-lock.json` to the list of ignored files in `.gitignore`.
* Add `package-lock.json` to the list of ignored files in `.npmignore`.

Add `package-lock.json` file generated by npm.

