### PR TITLE
Add basic unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "format": "prettier nodes credentials --write",
     "lint": "eslint nodes",
     "lintfix": "eslint nodes credentials package.json --fix",
-    "test": "echo \"No tests specified\"",
+    "test": "npm run build && node --test",
     "coverage": "mkdir -p coverage && echo 'no coverage' > coverage/placeholder.txt",
     "prepublishOnly": "npm run build && npm run lint -- -c .eslintrc.prepublish.js nodes"
   },

--- a/test/file-manager.test.js
+++ b/test/file-manager.test.js
@@ -1,0 +1,48 @@
+import test from "node:test";
+import { FileManager } from '../dist/nodes/FileManager/FileManager.node.js';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+function runNode(paramsArray, items = [{ json: {} }]) {
+  const node = new FileManager();
+  const context = {
+    getInputData() { return items; },
+    getNodeParameter(name, index) { return paramsArray[index][name]; },
+    continueOnFail() { return false; },
+    getNode() { return { name: 'fileManager' }; },
+  };
+  return node.execute.call(context);
+}
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'fm-'));
+}
+
+test('create file', async () => {
+  const dir = tmpDir();
+  const file = path.join(dir, 'test.txt');
+  await runNode([{ operation: 'create', sourcePath: file }]);
+  assert.ok(fs.existsSync(file));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('copy file', async () => {
+  const dir = tmpDir();
+  const src = path.join(dir, 'src.txt');
+  const dst = path.join(dir, 'dst.txt');
+  fs.writeFileSync(src, 'hello');
+  await runNode([{ operation: 'copy', sourcePath: src, destinationPath: dst }]);
+  assert.ok(fs.existsSync(dst));
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('remove file', async () => {
+  const dir = tmpDir();
+  const file = path.join(dir, 'remove.txt');
+  fs.writeFileSync(file, 'bye');
+  await runNode([{ operation: 'remove', sourcePath: file }]);
+  assert.ok(!fs.existsSync(file));
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- set up test script using Node's built-in test runner
- test create, copy and remove operations of the File Manager node

## Testing
- `npm test`