### PR TITLE
Add metadata operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,17 @@ The File Manager node provides the following operations:
 - **append** — Appends data to the end of a file.
 - **list** — Lists the entries of a directory.
 - **exists** — Checks if a path exists.
+- **metadata** — Returns metadata for a file or directory.
 
 ### Node Parameters
 
 | Parameter        | Description                                                                         |
 | ---------------- | ----------------------------------------------------------------------------------- |
-| Operation        | The action to perform: `create`, `copy`, `move`, `remove`, `rename`, `read`, `write`, `append`, `list`, `exists`. |
+| Operation        | The action to perform: `create`, `copy`, `move`, `remove`, `rename`, `read`, `write`, `append`, `list`, `exists`, `metadata`. |
 | Source Path      | Path to the file or directory to operate on. |
 | Destination Path | Target path for `copy`, `move`, and `rename` operations. |
 | Recursive        | Whether to delete directories recursively for `remove` operation (default: `true`). |
-| Target Path      | Path for `read`, `write`, `append`, `list`, and `exists` operations. |
+| Target Path      | Path for `read`, `write`, `append`, `list`, `exists`, and `metadata` operations. |
 | Data             | Content to use for `write` and `append` operations. |
 | Encoding         | File encoding for `read`, `write`, and `append` (default: `utf8`). |
 

--- a/nodes/FileManager/FileManager.node.ts
+++ b/nodes/FileManager/FileManager.node.ts
@@ -34,6 +34,7 @@ export class FileManager implements INodeType {
           { name: 'Create', value: 'create' },
           { name: 'Exists', value: 'exists' },
           { name: 'List', value: 'list' },
+          { name: 'Metadata', value: 'metadata' },
           { name: 'Move', value: 'move' },
           { name: 'Read', value: 'read' },
           { name: 'Remove', value: 'remove' },
@@ -87,7 +88,7 @@ export class FileManager implements INodeType {
         required: true,
         displayOptions: {
           show: {
-            operation: ['read', 'write', 'append', 'list', 'exists'],
+            operation: ['read', 'write', 'append', 'list', 'exists', 'metadata'],
           },
         },
       },
@@ -260,6 +261,18 @@ export class FileManager implements INodeType {
             break;
           }
 
+          case 'metadata': {
+            const targetPath = this.getNodeParameter('targetPath', i) as string;
+            const stats = await fs.lstat(targetPath);
+            inputItems[i].json.size = stats.size;
+            inputItems[i].json.mtime = stats.mtime;
+            inputItems[i].json.atime = stats.atime;
+            inputItems[i].json.isDirectory = stats.isDirectory();
+            inputItems[i].json.isFile = stats.isFile();
+            inputItems[i].json.targetPath = targetPath;
+            break;
+          }
+
           default:
             throw new NodeOperationError(this.getNode(), `Unknown operation "${operation}"`);
         }
@@ -273,7 +286,7 @@ export class FileManager implements INodeType {
         if (['copy', 'move', 'rename'].includes(operation)) {
           inputItems[i].json.destinationPath = this.getNodeParameter('destinationPath', i) as string;
         }
-        if (['read', 'write', 'append', 'list', 'exists'].includes(operation)) {
+        if (['read', 'write', 'append', 'list', 'exists', 'metadata'].includes(operation)) {
           inputItems[i].json.targetPath = this.getNodeParameter('targetPath', i) as string;
         }
         returnItems.push(inputItems[i]);

--- a/test/file-manager.test.js
+++ b/test/file-manager.test.js
@@ -94,3 +94,16 @@ test('exists path', async () => {
   assert.strictEqual(res2.json.exists, false);
   fs.rmSync(dir, { recursive: true, force: true });
 });
+
+test('metadata path', async () => {
+  const dir = tmpDir();
+  const file = path.join(dir, 'meta.txt');
+  fs.writeFileSync(file, 'hello');
+  const [[res]] = await runNode([{ operation: 'metadata', targetPath: file }]);
+  assert.strictEqual(res.json.size, 5);
+  assert.strictEqual(res.json.isFile, true);
+  assert.strictEqual(res.json.isDirectory, false);
+  assert.ok(res.json.mtime);
+  assert.ok(res.json.atime);
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- add `Metadata` option to FileManager node
- read path metadata via `fs.lstat`
- test metadata operation
- document new operation in README

## Testing
- `npm test`