### PR TITLE
Add chmod operation to File Manager node

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The File Manager node provides the following operations:
 - **read** — Reads the contents of a file.
 - **write** — Writes data to a file, replacing the existing contents.
 - **append** — Appends data to the end of a file.
+- **change permissions** — Updates the mode bits of a file or directory.
 - **list** — Lists the entries of a directory.
 - **exists** — Checks if a path exists.
 - **metadata** — Returns metadata for a file or directory.
@@ -40,13 +41,14 @@ The File Manager node provides the following operations:
 
 | Parameter        | Description                                                                         |
 | ---------------- | ----------------------------------------------------------------------------------- |
-| Operation        | The action to perform: `create`, `copy`, `move`, `remove`, `rename`, `read`, `write`, `append`, `list`, `exists`, `metadata`. |
+| Operation        | The action to perform: `create`, `copy`, `move`, `remove`, `rename`, `read`, `write`, `append`, `change permissions`, `list`, `exists`, `metadata`. |
 | Source Path      | Path to the file or directory to operate on. |
 | Destination Path | Target path for `copy`, `move`, and `rename` operations. |
 | Recursive        | Whether to delete directories recursively for `remove` operation (default: `true`). |
-| Target Path      | Path for `read`, `write`, `append`, `list`, `exists`, and `metadata` operations. |
+| Target Path      | Path for `read`, `write`, `append`, `change permissions`, `list`, `exists`, and `metadata` operations. |
 | Data             | Content to use for `write` and `append` operations. |
 | Encoding         | File encoding for `read`, `write`, and `append` (default: `utf8`). |
+| Mode             | Numeric mode for `change permissions` (default: `0o644`). |
 
 ### Example Usage
 
@@ -55,6 +57,7 @@ The File Manager node provides the following operations:
 3. Enter `/tmp/example.txt` as **Source Path**.
 4. Enter `/tmp/example-copy.txt` as **Destination Path**.
 5. Execute the workflow to copy the file.
+6. To change permissions, set **Operation** to `change permissions`, provide a **Target Path**, and specify the numeric **Mode** (for example, `0o600`).
 
 ## Version History
 

--- a/nodes/FileManager/FileManager.node.ts
+++ b/nodes/FileManager/FileManager.node.ts
@@ -30,6 +30,7 @@ export class FileManager implements INodeType {
         noDataExpression: true,
         options: [
           { name: 'Append', value: 'append' },
+          { name: 'Change Permissions', value: 'chmod' },
           { name: 'Copy', value: 'copy' },
           { name: 'Create', value: 'create' },
           { name: 'Exists', value: 'exists' },
@@ -88,7 +89,7 @@ export class FileManager implements INodeType {
         required: true,
         displayOptions: {
           show: {
-            operation: ['read', 'write', 'append', 'list', 'exists', 'metadata'],
+            operation: ['read', 'write', 'append', 'list', 'exists', 'metadata', 'chmod'],
           },
         },
       },
@@ -113,6 +114,18 @@ export class FileManager implements INodeType {
         displayOptions: {
           show: {
             operation: ['read', 'write', 'append'],
+          },
+        },
+      },
+      {
+        displayName: 'Mode',
+        name: 'mode',
+        type: 'number',
+        default: 0o644,
+        description: 'Unix permission bits, e.g. 644',
+        displayOptions: {
+          show: {
+            operation: ['chmod'],
           },
         },
       },
@@ -240,6 +253,15 @@ export class FileManager implements INodeType {
             break;
           }
 
+          case 'chmod': {
+            const targetPath = this.getNodeParameter('targetPath', i) as string;
+            const mode = this.getNodeParameter('mode', i) as number;
+            await fs.chmod(targetPath, mode);
+            inputItems[i].json.targetPath = targetPath;
+            inputItems[i].json.mode = mode;
+            break;
+          }
+
           case 'list': {
             const targetPath = this.getNodeParameter('targetPath', i) as string;
             const files = await fs.readdir(targetPath);
@@ -286,7 +308,7 @@ export class FileManager implements INodeType {
         if (['copy', 'move', 'rename'].includes(operation)) {
           inputItems[i].json.destinationPath = this.getNodeParameter('destinationPath', i) as string;
         }
-        if (['read', 'write', 'append', 'list', 'exists', 'metadata'].includes(operation)) {
+        if (['read', 'write', 'append', 'list', 'exists', 'metadata', 'chmod'].includes(operation)) {
           inputItems[i].json.targetPath = this.getNodeParameter('targetPath', i) as string;
         }
         returnItems.push(inputItems[i]);

--- a/test/file-manager.test.js
+++ b/test/file-manager.test.js
@@ -107,3 +107,13 @@ test('metadata path', async () => {
   assert.ok(res.json.atime);
   fs.rmSync(dir, { recursive: true, force: true });
 });
+
+test('chmod file', async () => {
+  const dir = tmpDir();
+  const file = path.join(dir, 'chmod.txt');
+  fs.writeFileSync(file, 'perm');
+  await runNode([{ operation: 'chmod', targetPath: file, mode: 0o600 }]);
+  const mode = fs.statSync(file).mode & 0o777;
+  assert.strictEqual(mode, 0o600);
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- add `Change Permissions` operation
- support numeric `mode` parameter when using chmod
- implement chmod execution logic
- document new operation and example usage
- test changing file permissions

## Testing
- `npm test`