### PR TITLE
Add compression to file manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # n8n-nodes-filemanager
 
-A community node for [n8n](https://n8n.io/) to manage files and folders on disk. Supports generic operations: create, copy, move, remove, and rename files and directories.
+A community node for [n8n](https://n8n.io/) to manage files and folders on disk. Supports generic operations: create, copy, move, remove, rename, compress, and extract files and directories.
 
 ## Installation
 
@@ -26,8 +26,10 @@ The File Manager node provides the following operations:
 
 - **create** — Creates a file or directory. If the path has an extension, a file is created; otherwise, a directory is created.
 - **copy** — Copies a file or directory to a new location.
+- **compress** — Archives a file or directory into a `.tar.gz` file.
 - **move** — Moves (renames) a file or directory to a new location.
 - **remove** — Deletes a file or directory. Supports recursive deletion of directories.
+- **extract** — Extracts a `.tar.gz` archive into a directory.
 - **rename** — Alias for move; renames a file or directory.
 - **read** — Reads the contents of a file.
 - **write** — Writes data to a file, replacing the existing contents.
@@ -41,9 +43,9 @@ The File Manager node provides the following operations:
 
 | Parameter        | Description                                                                         |
 | ---------------- | ----------------------------------------------------------------------------------- |
-| Operation        | The action to perform: `create`, `copy`, `move`, `remove`, `rename`, `read`, `write`, `append`, `change permissions`, `list`, `exists`, `metadata`. |
+| Operation        | The action to perform: `append`, `change permissions`, `compress`, `copy`, `create`, `exists`, `extract`, `list`, `metadata`, `move`, `read`, `remove`, `rename`, `write`. |
 | Source Path      | Path to the file or directory to operate on. |
-| Destination Path | Target path for `copy`, `move`, and `rename` operations. |
+| Destination Path | Target path for `copy`, `move`, `rename`, `compress`, and `extract` operations. |
 | Recursive        | Whether to delete directories recursively for `remove` operation (default: `true`). |
 | Target Path      | Path for `read`, `write`, `append`, `change permissions`, `list`, `exists`, and `metadata` operations. |
 | Data             | Content to use for `write` and `append` operations. |

--- a/nodes/FileManager/FileManager.node.ts
+++ b/nodes/FileManager/FileManager.node.ts
@@ -6,10 +6,10 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionType } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { promises as fs, createWriteStream, createReadStream } from 'fs';
+import { promises as fs, createReadStream } from 'fs';
 import * as path from 'path';
 import { spawn } from 'child_process';
-import { createGzip, createGunzip } from 'zlib';
+import { createGunzip } from 'zlib';
 
 export class FileManager implements INodeType {
   description: INodeTypeDescription = {

--- a/nodes/FileManager/FileManager.node.ts
+++ b/nodes/FileManager/FileManager.node.ts
@@ -63,7 +63,7 @@ export class FileManager implements INodeType {
         type: 'string',
         default: '',
         placeholder: '/path/to/destination',
-        description: 'Path to copy, move, rename, compress to, or extract to',
+        description: 'Target path for copy, move, rename, compress, and extract operations',
         required: true,
         displayOptions: {
           show: {

--- a/nodes/FileManager/FileManager.node.ts
+++ b/nodes/FileManager/FileManager.node.ts
@@ -216,16 +216,14 @@ export class FileManager implements INodeType {
             const sourcePath = this.getNodeParameter('sourcePath', i) as string;
             const destinationPath = this.getNodeParameter('destinationPath', i) as string;
             await new Promise<void>((resolve, reject) => {
-              const output = createWriteStream(destinationPath);
-              const gzip = createGzip();
-              const tar = spawn('tar', ['-cf', '-', path.basename(sourcePath)], {
+              const tar = spawn('tar', ['-czf', destinationPath, path.basename(sourcePath)], {
                 cwd: path.dirname(sourcePath),
               });
               tar.on('error', reject);
               tar.on('close', (code) => {
                 if (code !== 0) reject(new Error(`tar exited with code ${code}`));
+                else resolve();
               });
-              tar.stdout.pipe(gzip).pipe(output).on('finish', resolve).on('error', reject);
             });
             break;
           }

--- a/nodes/FileManager/FileManager.node.ts
+++ b/nodes/FileManager/FileManager.node.ts
@@ -6,8 +6,10 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionType } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
-import { promises as fs } from 'fs';
+import { promises as fs, createWriteStream, createReadStream } from 'fs';
 import * as path from 'path';
+import { spawn } from 'child_process';
+import { createGzip, createGunzip } from 'zlib';
 
 export class FileManager implements INodeType {
   description: INodeTypeDescription = {
@@ -31,9 +33,11 @@ export class FileManager implements INodeType {
         options: [
           { name: 'Append', value: 'append' },
           { name: 'Change Permissions', value: 'chmod' },
+          { name: 'Compress', value: 'compress' },
           { name: 'Copy', value: 'copy' },
           { name: 'Create', value: 'create' },
           { name: 'Exists', value: 'exists' },
+          { name: 'Extract', value: 'extract' },
           { name: 'List', value: 'list' },
           { name: 'Metadata', value: 'metadata' },
           { name: 'Move', value: 'move' },
@@ -59,11 +63,11 @@ export class FileManager implements INodeType {
         type: 'string',
         default: '',
         placeholder: '/path/to/destination',
-        description: 'Path to copy, move, or rename to',
+        description: 'Path to copy, move, rename, compress to, or extract to',
         required: true,
         displayOptions: {
           show: {
-            operation: ['copy', 'move', 'rename'],
+            operation: ['compress', 'copy', 'extract', 'move', 'rename'],
           },
         },
       },
@@ -208,6 +212,42 @@ export class FileManager implements INodeType {
             break;
           }
 
+          case 'compress': {
+            const sourcePath = this.getNodeParameter('sourcePath', i) as string;
+            const destinationPath = this.getNodeParameter('destinationPath', i) as string;
+            await new Promise<void>((resolve, reject) => {
+              const output = createWriteStream(destinationPath);
+              const gzip = createGzip();
+              const tar = spawn('tar', ['-cf', '-', path.basename(sourcePath)], {
+                cwd: path.dirname(sourcePath),
+              });
+              tar.on('error', reject);
+              tar.on('close', (code) => {
+                if (code !== 0) reject(new Error(`tar exited with code ${code}`));
+              });
+              tar.stdout.pipe(gzip).pipe(output).on('finish', resolve).on('error', reject);
+            });
+            break;
+          }
+
+          case 'extract': {
+            const sourcePath = this.getNodeParameter('sourcePath', i) as string;
+            const destinationPath = this.getNodeParameter('destinationPath', i) as string;
+            await fs.mkdir(destinationPath, { recursive: true });
+            await new Promise<void>((resolve, reject) => {
+              const input = createReadStream(sourcePath);
+              const gunzip = createGunzip();
+              const tar = spawn('tar', ['-xf', '-', '-C', destinationPath]);
+              tar.on('error', reject);
+              tar.on('close', (code) => {
+                if (code !== 0) reject(new Error(`tar exited with code ${code}`));
+                else resolve();
+              });
+              input.pipe(gunzip).pipe(tar.stdin).on('error', reject);
+            });
+            break;
+          }
+
           case 'create': {
             const sourcePath = this.getNodeParameter('sourcePath', i) as string;
             const ext = path.extname(sourcePath);
@@ -302,10 +342,10 @@ export class FileManager implements INodeType {
         // Prepare output data
         inputItems[i].json.operation = operation;
         inputItems[i].json.success = true;
-        if (['copy', 'move', 'rename', 'remove', 'create'].includes(operation)) {
+        if (['compress', 'copy', 'extract', 'move', 'rename', 'remove', 'create'].includes(operation)) {
           inputItems[i].json.sourcePath = this.getNodeParameter('sourcePath', i) as string;
         }
-        if (['copy', 'move', 'rename'].includes(operation)) {
+        if (['compress', 'copy', 'extract', 'move', 'rename'].includes(operation)) {
           inputItems[i].json.destinationPath = this.getNodeParameter('destinationPath', i) as string;
         }
         if (['read', 'write', 'append', 'list', 'exists', 'metadata', 'chmod'].includes(operation)) {

--- a/test/file-manager.test.js
+++ b/test/file-manager.test.js
@@ -117,3 +117,21 @@ test('chmod file', async () => {
   assert.strictEqual(mode, 0o600);
   fs.rmSync(dir, { recursive: true, force: true });
 });
+
+test('compress and extract directory', async () => {
+  const dir = tmpDir();
+  const srcDir = path.join(dir, 'src');
+  const dstDir = path.join(dir, 'dst');
+  const archive = path.join(dir, 'archive.tar.gz');
+  fs.mkdirSync(srcDir);
+  const file = path.join(srcDir, 'hello.txt');
+  fs.writeFileSync(file, 'hi');
+
+  await runNode([{ operation: 'compress', sourcePath: srcDir, destinationPath: archive }]);
+  assert.ok(fs.existsSync(archive));
+
+  await runNode([{ operation: 'extract', sourcePath: archive, destinationPath: dstDir }]);
+  const extracted = path.join(dstDir, 'src', 'hello.txt');
+  assert.strictEqual(fs.readFileSync(extracted, 'utf8'), 'hi');
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- add `compress` and `extract` operations to FileManager node
- update documentation for new operations
- support archiving via tar.gz using built-in utilities
- test compress and extract behaviour

## Testing
- `npm test`